### PR TITLE
New option: Ignore queue priority

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -208,6 +208,16 @@
                 "Default = No."
             ],
             "select": ["Yes", "No"]
+        },
+        {
+            "name": "IgnoreQueuePriority",
+            "displayName": "IgnoreQueuePriority",
+            "value": "No",
+            "description": [
+                "Ignore queue priority and always validate items immediately",
+                "Default = No."
+            ],
+            "select": ["Yes", "No"]
         }
     ],
     "commands": [


### PR DESCRIPTION
My use case was that I wanted to always validate new downloads if I add then manually and this did the trick. Even if there are items already in downloading, etc. Might benefit others too.