### PR TITLE
Add: additional options for setting post-processing params on complet…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
             "value": "",
             "description": [
                 "Sets post-processing parameters for the group when the completion check succeeds.",
-                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Specify parameters as 'CompletionCheck=False, DownloadStatus=Failure'.",
                 "Default = blank."
             ],
             "select": []
@@ -108,7 +108,7 @@
             "value": "",
             "description": [
                 "Sets post-processing parameters for the group when the completion check fails.",
-                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Specify parameters as 'CompletionCheck=True, DownloadStatus=Success'.",
                 "Default = blank."
             ],
             "select": []
@@ -155,7 +155,7 @@
             "description": [
                 "Check all archives when no pars.",
                 "Force a full check on all the archives articles in the release when no or",
-                "only 1 par file is included. This to garantee all articles are there and you",
+                "only 1 par file is included. This to guarantee all articles are there and you",
                 "don't waste bandwidth because just 1 article is missing.",
                 "Default = Yes."
             ],
@@ -168,7 +168,7 @@
             "description": [
                 "Categories to check for completion.",
                 "Comma separated list like 'TV-HD, TV, Movies, etc'. Leave blank for all",
-                "categories. Note that the category of an NZB file is shown in the donwload",
+                "categories. Note that the category of an NZB file is shown in the download",
                 "and history queue.",
                 "Default = blank."
             ],
@@ -183,7 +183,7 @@
                 "Comma separated list like '1, 3, 4'. Leave blank for all news-servers.",
                 "News-server numbers are equal to the server numbering in the NZBGet settings",
                 "on the NEWS-SERVERS tab.",
-                "Suggestion is the specify atleast your main news-servers.",
+                "Suggestion is the specify at least your main news-servers.",
                 "Default = blank."
             ],
             "select": []

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,8 @@
             "value": "",
             "description": [
                 "Sets post-processing parameters for the group when the completion check succeeds.",
-                "Specify parameters as 'CompletionCheck=False, DownloadStatus=Failure'.",
+                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Example: 'CompletionCheck=True, DownloadStatus=Success'.",
                 "Default = blank."
             ],
             "select": []
@@ -107,8 +108,9 @@
             "displayName": "SetParamsOnFailure",
             "value": "",
             "description": [
-                "Sets post-processing parameters for the group when the completion check fails.",
-                "Specify parameters as 'CompletionCheck=True, DownloadStatus=Success'.",
+                "Sets post-processing parameters for the group when the completion check succeeds.",
+                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Example: 'CompletionCheck=False, DownloadStatus=Failure'.",
                 "Default = blank."
             ],
             "select": []

--- a/manifest.json
+++ b/manifest.json
@@ -92,6 +92,28 @@
             "select": ["Yes", "No"]
         },
         {
+            "name": "SetParamsOnSuccess",
+            "displayName": "SetParamsOnSuccess",
+            "value": "",
+            "description": [
+                "Sets post-processing parameters for the group when the completion check succeeds.",
+                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Default = blank."
+            ],
+            "select": []
+        },
+        {
+            "name": "SetParamsOnFailure",
+            "displayName": "SetParamsOnFailure",
+            "value": "",
+            "description": [
+                "Sets post-processing parameters for the group when the completion check fails.",
+                "Specify parameters as 'ParamName=ParamValue, ParamName2=ParamValue2'.",
+                "Default = blank."
+            ],
+            "select": []
+        },
+        {
             "name": "CheckLimit",
             "displayName": "CheckLimit",
             "value": 10,
@@ -195,6 +217,16 @@
             "select": []
         },
         {
+            "name": "IgnoreQueuePriority",
+            "displayName": "IgnoreQueuePriority",
+            "value": "No",
+            "description": [
+                "Ignore queue priority and always validate items immediately",
+                "Default = No."
+            ],
+            "select": ["Yes", "No"]
+        },
+        {
             "name": "Verbose",
             "displayName": "Verbose",
             "value": "No",
@@ -211,16 +243,6 @@
             "description": [
                 "Print even more info to the log for debugging.",
                 "This will print your news-server passwords in the logs too!.",
-                "Default = No."
-            ],
-            "select": ["Yes", "No"]
-        },
-        {
-            "name": "IgnoreQueuePriority",
-            "displayName": "IgnoreQueuePriority",
-            "value": "No",
-            "description": [
-                "Ignore queue priority and always validate items immediately",
                 "Default = No."
             ],
             "select": ["Yes", "No"]


### PR DESCRIPTION
### Description 

Added additional options for setting post-processing params on completion success/failure:
 -   SetParamsOnSuccess
 -   SetParamsOnFailure 
 
Parameters can be specified as comma separated list, e.g: 
`ParamName=ParamValue, ParamName2=ParamValue2`
 
 ### Testing
 
 - macOS Ventura / nzbget 24.9-testing
